### PR TITLE
Fix broken menu item 'about'

### DIFF
--- a/SimpleRestClient/MainForm.cs
+++ b/SimpleRestClient/MainForm.cs
@@ -17,5 +17,11 @@ namespace SimpleRestClient
         {
             
         }
+
+        private void AboutToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Form about = new AboutForm();
+            about.ShowDialog();
+        }
     }
 }


### PR DESCRIPTION
Add AboutToolStripMenuItem_Click handler to MainForm.cs